### PR TITLE
handle create svc in goalert

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,10 +1,16 @@
 package config
 
 const (
-	OperatorName             string = "configure-goalert-operator"
-	OperatorNamespace        string = "openshift-configure-goalert-operator"
-	GoalertUsernameSecretKey string = "USERNAME"
-	GoalertPasswordSecretKey string = "PASSWORD"
+	OperatorName              string = "configure-goalert-operator"
+	OperatorNamespace         string = "openshift-configure-goalert-operator"
+	GoalertUsernameSecretKey  string = "USERNAME"
+	GoalertPasswordSecretKey  string = "PASSWORD"
+	GoalertHighSecretKey      string = "GOALERT_URL_HIGH"
+	GoalertLowSecretKey       string = "GOALERT_URL_LOW"
+	GoalertHeartbeatSecretKey string = "GOALERT_HEARTBEAT"
+	GoalertFinalizerPrefix    string = "goalert.managed.openshift.io/goalert-"
+	ConfigMapSuffix           string = "-goalert-config"
+	SecretSuffix              string = "-goalert-secret"
 )
 
 // Name is used to generate the name of secondary resources (SyncSets,

--- a/controllers/goalertintegration/clusterdeployment_created.go
+++ b/controllers/goalertintegration/clusterdeployment_created.go
@@ -64,10 +64,12 @@ func (r *GoalertIntegrationReconciler) handleCreate(gclient goalert.Client, gi *
 
 	highSvcID, err := gclient.CreateService(dataHighSvc, sessionCookie)
 	if err != nil {
+		r.reqLogger.Error(err, "Failed to create service for High alerts")
 		return err
 	}
 	lowSvcID, err := gclient.CreateService(dataLowSvc, sessionCookie)
 	if err != nil {
+		r.reqLogger.Error(err, "Failed to create service for Low alerts")
 		return err
 	}
 
@@ -85,9 +87,11 @@ func (r *GoalertIntegrationReconciler) handleCreate(gclient goalert.Client, gi *
 
 	highIntKeyID, err := gclient.CreateIntegrationKey(dataIntKeyHighSvc, sessionCookie)
 	if err != nil {
+		r.reqLogger.Error(err, "Failed to create integration key for high alerts")
 		return err
 	}
 	lowIntKeyID, err := gclient.CreateIntegrationKey(dataIntKeyLowSvc, sessionCookie)
+	r.reqLogger.Error(err, "Failed to create integration key for low alerts")
 	if err != nil {
 		return err
 	}
@@ -101,6 +105,7 @@ func (r *GoalertIntegrationReconciler) handleCreate(gclient goalert.Client, gi *
 
 	heartbeatMonitorID, err := gclient.CreateHeartbeatMonitor(dataHeartbeatMonitor, sessionCookie)
 	if err != nil {
+		r.reqLogger.Error(err, "Failed to create heartbeat monitor")
 		return err
 	}
 
@@ -147,7 +152,7 @@ func (r *GoalertIntegrationReconciler) handleCreate(gclient goalert.Client, gi *
 			string(sc.Data[config.GoalertHeartbeatSecretKey]) != heartbeatMonitorID {
 			r.reqLogger.Info("Secret data have changed, delete the secret first")
 			if err = r.Delete(context.TODO(), secret); err != nil {
-				log.Info("failed to delete existing pd secret")
+				log.Info("failed to delete existing goalert secret")
 				return err
 			}
 			r.reqLogger.Info("creating goalert secret", "ClusterDeployment.Namespace", cd.Namespace)

--- a/controllers/goalertintegration/clusterdeployment_created.go
+++ b/controllers/goalertintegration/clusterdeployment_created.go
@@ -110,7 +110,7 @@ func (r *GoalertIntegrationReconciler) handleCreate(gclient goalert.Client, gi *
 	}
 
 	// save config map
-	newCM := kube.GenerateConfigMap(cd.Namespace, configMapName, highSvcID, lowSvcID, highIntKeyID, lowIntKeyID, highEscalationPolicyID, lowEscalationPolicyID)
+	newCM := kube.GenerateConfigMap(cd.Namespace, configMapName, highSvcID, lowSvcID, highEscalationPolicyID, lowEscalationPolicyID)
 	if err = controllerutil.SetControllerReference(cd, newCM, r.Scheme); err != nil {
 		r.reqLogger.Error(err, "Error setting controller reference on configmap")
 		return err

--- a/controllers/goalertintegration/clusterdeployment_created.go
+++ b/controllers/goalertintegration/clusterdeployment_created.go
@@ -1,11 +1,186 @@
 package goalertintegration
 
 import (
+	"context"
+	"net/http"
+	"strings"
+
 	goalertv1alpha1 "github.com/openshift/configure-goalert-operator/api/v1alpha1"
+	"github.com/openshift/configure-goalert-operator/config"
+	"github.com/openshift/configure-goalert-operator/pkg/goalert"
+	"github.com/openshift/configure-goalert-operator/pkg/kube"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	util "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // Scaffold of func to handle creation of new clusters OSD-16306
-func (r *GoalertIntegrationReconciler) handleCreate(gi *goalertv1alpha1.GoalertIntegration, cd *hivev1.ClusterDeployment) error {
+func (r *GoalertIntegrationReconciler) handleCreate(gclient goalert.Client, gi *goalertv1alpha1.GoalertIntegration, sessionCookie *http.Cookie, cd *hivev1.ClusterDeployment) error {
 
+	var (
+		// secretName is the name of the Secret deployed to the target
+		// cluster, and also the name of the SyncSet that causes it to
+		// be deployed.
+		secretName string = config.Name(gi.Spec.ServicePrefix, cd.Name, config.SecretSuffix)
+		// There can be more than one GoalertIntegration that causes
+		// creation of resources for a ClusterDeployment, and each one
+		// will need a finalizer here. We add a suffix of the CR
+		// name to distinguish them.
+		finalizer string = config.GoalertFinalizerPrefix + gi.Name
+		// configMapName is the name of the ConfigMap containing the
+		// SERVICE_ID and INTEGRATION_ID
+		configMapName          string = config.Name(gi.Spec.ServicePrefix, cd.Name, config.ConfigMapSuffix)
+		highEscalationPolicyID string = gi.Spec.HighEscalationPolicy
+		lowEscalationPolicyID  string = gi.Spec.LowEscalationPolicy
+	)
+
+	if !util.ContainsFinalizer(cd, finalizer) {
+		baseToPatch := client.MergeFrom(cd.DeepCopy())
+		util.AddFinalizer(cd, finalizer)
+		return r.Patch(context.TODO(), cd, baseToPatch)
+	}
+
+	clusterID := GetClusterID(cd)
+
+	// Load data to create new service in Goalert
+	dataHighSvc := &goalert.Data{
+		EscalationPolicyID: gi.Spec.HighEscalationPolicy,
+		Name:               clusterID + " - High",
+		Description:        cd.Spec.ClusterName,
+		Favorite:           true,
+	}
+
+	dataLowSvc := &goalert.Data{
+		EscalationPolicyID: gi.Spec.LowEscalationPolicy,
+		Name:               clusterID + " - Low",
+		Description:        cd.Spec.ClusterName,
+		Favorite:           true,
+	}
+
+	highSvcID, err := gclient.CreateService(dataHighSvc, sessionCookie)
+	if err != nil {
+		return err
+	}
+	lowSvcID, err := gclient.CreateService(dataLowSvc, sessionCookie)
+	if err != nil {
+		return err
+	}
+
+	// Load data to create integration key for alertmanager
+	dataIntKeyHighSvc := &goalert.Data{
+		Id:   highSvcID,
+		Type: "prometheusAlertmanager",
+		Name: "High alerts",
+	}
+	dataIntKeyLowSvc := &goalert.Data{
+		Id:   lowSvcID,
+		Type: "prometheusAlertmanager",
+		Name: "Low alerts",
+	}
+
+	highIntKeyID, err := gclient.CreateIntegrationKey(dataIntKeyHighSvc, sessionCookie)
+	if err != nil {
+		return err
+	}
+	lowIntKeyID, err := gclient.CreateIntegrationKey(dataIntKeyLowSvc, sessionCookie)
+	if err != nil {
+		return err
+	}
+
+	// Load data to create heartbeatmonitor
+	dataHeartbeatMonitor := &goalert.Data{
+		Id:      highSvcID,
+		Name:    clusterID,
+		Timeout: 15,
+	}
+
+	heartbeatMonitorID, err := gclient.CreateHeartbeatMonitor(dataHeartbeatMonitor, sessionCookie)
+	if err != nil {
+		return err
+	}
+
+	// save config map
+	newCM := kube.GenerateConfigMap(cd.Namespace, configMapName, highSvcID, lowSvcID, highIntKeyID, lowIntKeyID, highEscalationPolicyID, lowEscalationPolicyID)
+	if err = controllerutil.SetControllerReference(cd, newCM, r.Scheme); err != nil {
+		r.reqLogger.Error(err, "Error setting controller reference on configmap")
+		return err
+	}
+
+	if err := r.Create(context.TODO(), newCM); err != nil {
+		if errors.IsAlreadyExists(err) {
+			if updateErr := r.Update(context.TODO(), newCM); updateErr != nil {
+				r.reqLogger.Error(err, "Error updating existing configmap", "Name", configMapName)
+				return err
+			}
+			return nil
+		}
+		r.reqLogger.Error(err, "Error creating configmap", "Name", configMapName)
+		return err
+	}
+
+	//add secret part
+	secret := kube.GenerateGoalertSecret(cd.Namespace, secretName, highIntKeyID, lowIntKeyID, heartbeatMonitorID)
+	r.reqLogger.Info("creating goalert secret", "ClusterDeployment.Namespace", cd.Namespace)
+	//add reference
+	if err = controllerutil.SetControllerReference(cd, secret, r.Scheme); err != nil {
+		r.reqLogger.Error(err, "Error setting controller reference on secret", "ClusterDeployment.Namespace", cd.Namespace)
+		return err
+	}
+	if err = r.Create(context.TODO(), secret); err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return err
+		}
+
+		r.reqLogger.Info("the goalert secret exist, check if IntegrationKey are changed or not", "ClusterDeployment.Namespace", cd.Namespace)
+		sc := &corev1.Secret{}
+		err = r.Get(context.TODO(), types.NamespacedName{Name: secret.Name, Namespace: cd.Namespace}, sc)
+		if err != nil {
+			return nil
+		}
+		if string(sc.Data[config.GoalertHighSecretKey]) != highIntKeyID ||
+			string(sc.Data[config.GoalertLowSecretKey]) != lowIntKeyID ||
+			string(sc.Data[config.GoalertHeartbeatSecretKey]) != heartbeatMonitorID {
+			r.reqLogger.Info("Secret data have changed, delete the secret first")
+			if err = r.Delete(context.TODO(), secret); err != nil {
+				log.Info("failed to delete existing pd secret")
+				return err
+			}
+			r.reqLogger.Info("creating goalert secret", "ClusterDeployment.Namespace", cd.Namespace)
+			if err = r.Create(context.TODO(), secret); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Create syncset that will propagate secret to customer cluster
+	r.reqLogger.Info("Creating syncset", "ClusterDeployment.Namespace", cd.Namespace)
+	ss := &hivev1.SyncSet{}
+	err = r.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: cd.Namespace}, ss)
+	if err != nil {
+		r.reqLogger.Info("error finding the old syncset")
+		if !errors.IsNotFound(err) {
+			return err
+		}
+		r.reqLogger.Info("syncset not found , create a new one on this ")
+		ss = kube.GenerateSyncSet(cd.Namespace, cd.Name, secret, gi)
+		if err = controllerutil.SetControllerReference(cd, ss, r.Scheme); err != nil {
+			r.reqLogger.Error(err, "Error setting controller reference on syncset", "ClusterDeployment.Namespace", cd.Namespace)
+			return err
+		}
+		if err := r.Create(context.TODO(), ss); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func GetClusterID(cd *hivev1.ClusterDeployment) string {
+	uid := strings.Split(cd.Namespace, "-")
+	return "Fedramp-" + uid[len(uid)-1]
 }

--- a/pkg/goalert/service.go
+++ b/pkg/goalert/service.go
@@ -20,6 +20,14 @@ func defaultURL() *url.URL {
 	return url
 }
 
+// Client is a wrapper interface for the graphqlClient to allow for easier testing
+type Client interface {
+	CreateService(data *Data, sessionCookie *http.Cookie) (string, error)
+	CreateIntegrationKey(data *Data, sessionCookie *http.Cookie) (string, error)
+	CreateHeartbeatMonitor(data *Data, sessionCookie *http.Cookie) (string, error)
+	DeleteService(data *Data, sessionCookie *http.Cookie)
+}
+
 // Wrapper for HTTP client
 type graphqlClient struct {
 	BaseURL    *url.URL

--- a/pkg/kube/configmap.go
+++ b/pkg/kube/configmap.go
@@ -6,7 +6,7 @@ import (
 )
 
 // GenerateConfigMap returns a configmap that can be created with the oc client
-func GenerateConfigMap(namespace string, cmName string, goalertHighServiceID, goalertLowServiceID, goalertHighIntegrationID, goalertLowIntegrationID, goalertHighEscalationPolicyID, goalertLowEscalationPlicyID string) *corev1.ConfigMap {
+func GenerateConfigMap(namespace string, cmName string, goalertHighServiceID, goalertLowServiceID, goalertHighEscalationPolicyID, goalertLowEscalationPlicyID string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmName,
@@ -15,8 +15,6 @@ func GenerateConfigMap(namespace string, cmName string, goalertHighServiceID, go
 		Data: map[string]string{
 			"HIGH_SERVICE_ID":           goalertHighServiceID,
 			"LOW_SERVICE_ID":            goalertLowServiceID,
-			"HIGH_INTEGRATION_ID":       goalertHighIntegrationID,
-			"LOW_INTEGRATION_ID":        goalertLowIntegrationID,
 			"HIGH_ESCALATION_POLICY_ID": goalertHighEscalationPolicyID,
 			"LOW_ESCALATION_POLICY_ID":  goalertLowEscalationPlicyID,
 		},

--- a/pkg/kube/configmap.go
+++ b/pkg/kube/configmap.go
@@ -1,0 +1,24 @@
+package kube
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GenerateConfigMap returns a configmap that can be created with the oc client
+func GenerateConfigMap(namespace string, cmName string, goalertHighServiceID, goalertLowServiceID, goalertHighIntegrationID, goalertLowIntegrationID, goalertHighEscalationPolicyID, goalertLowEscalationPlicyID string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"HIGH_SERVICE_ID":           goalertHighServiceID,
+			"LOW_SERVICE_ID":            goalertLowServiceID,
+			"HIGH_INTEGRATION_ID":       goalertHighIntegrationID,
+			"LOW_INTEGRATION_ID":        goalertLowIntegrationID,
+			"HIGH_ESCALATION_POLICY_ID": goalertHighEscalationPolicyID,
+			"LOW_ESCALATION_POLICY_ID":  goalertLowEscalationPlicyID,
+		},
+	}
+}

--- a/pkg/kube/syncset.go
+++ b/pkg/kube/syncset.go
@@ -1,0 +1,63 @@
+package kube
+
+import (
+	goalertv1alpha1 "github.com/openshift/configure-goalert-operator/api/v1alpha1"
+	"github.com/openshift/configure-goalert-operator/config"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GenerateSyncSet returns a syncset that can be created with the oc client
+func GenerateSyncSet(namespace string, clusterDeploymentName string, secret *corev1.Secret, gi *goalertv1alpha1.GoalertIntegration) *hivev1.SyncSet {
+	return &hivev1.SyncSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secret.Name,
+			Namespace: namespace,
+		},
+		Spec: hivev1.SyncSetSpec{
+			ClusterDeploymentRefs: []corev1.LocalObjectReference{
+				{
+					Name: clusterDeploymentName,
+				},
+			},
+			SyncSetCommonSpec: hivev1.SyncSetCommonSpec{
+				ResourceApplyMode: "Sync",
+				Secrets: []hivev1.SecretMapping{
+					{
+						SourceRef: hivev1.SecretReference{
+							Namespace: secret.Namespace,
+							Name:      secret.Name,
+						},
+						TargetRef: hivev1.SecretReference{
+							Namespace: gi.Spec.TargetSecretRef.Namespace,
+							Name:      gi.Spec.TargetSecretRef.Name,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// GenerateGoalertSecret returns a secret that can be created with the oc client
+func GenerateGoalertSecret(namespace string, name string, goalertHighIntegrationKey, goalertLowIntegrationKey, heartbeatKey string) *corev1.Secret {
+	secret := &corev1.Secret{
+		Type: "Opaque",
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			config.GoalertHighSecretKey:      []byte(goalertHighIntegrationKey),
+			config.GoalertLowSecretKey:       []byte(goalertLowIntegrationKey),
+			config.GoalertHeartbeatSecretKey: []byte(heartbeatKey),
+		},
+	}
+
+	return secret
+}


### PR DESCRIPTION
This PR adds the file that handles the creation of new services for new clusters in Goalert
The func handleCreate will create the new service, integration keys and heartbeat monitor and will add their ID into a secret
Unit tests need to be added
Jira: [OSD-16306](https://issues.redhat.com//browse/OSD-16306)