### PR TITLE
rm watch cm

### DIFF
--- a/controllers/goalertintegration/goalertintegration_controller.go
+++ b/controllers/goalertintegration/goalertintegration_controller.go
@@ -321,8 +321,5 @@ func (r *GoalertIntegrationReconciler) SetupWithManager(mgr ctrl.Manager) error 
 			Client: mgr.GetClient(),
 			Scheme: mgr.GetScheme(),
 		}).
-		Watches(&source.Kind{Type: &corev1.ConfigMap{}}, &enqueueRequestForConfigMap{
-			Client: mgr.GetClient(),
-		}).
 		Complete(r)
 }


### PR DESCRIPTION
This PR removes the logic in the controller that watches for changes in the configmaps. The configmaps weren't getting created properly when registering the service in goalert and as result, CGAO wasn't able to retrieve the service IDs from the configmaps when de-registering clusters from goalert