### PR TITLE
updates SSS to not create a VPCE in AppSRE prod since it houses GoAlert

### DIFF
--- a/hack/olm-artifacts-template.yaml
+++ b/hack/olm-artifacts-template.yaml
@@ -174,6 +174,10 @@ objects:
         operator: In
         values:
         - "true"
+      - key: appsre-prod
+        operator: NotIn
+        values:
+        - "true"        
       matchLabels:
         api.openshift.com/managed: "true"
     resourceApplyMode: Sync


### PR DESCRIPTION
Creating a VPCE with AVO in AppSRE prod is causing the operator to create a DNS entry targeting the VPCE in the cluster where GoAlert lives. This causes clusters configured to resolve AppSRE objects to use the wrong DNS value to access goalert. We do not and should not need to configure a VPC endpoint for GoAlert in AppSRE cluster since it can already reach GoAlert locally