### PR TITLE
fixes call to get API endpoint

### DIFF
--- a/controllers/goalertintegration/goalertintegration_controller.go
+++ b/controllers/goalertintegration/goalertintegration_controller.go
@@ -20,11 +20,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/openshift/configure-goalert-operator/pkg/localmetrics"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
+
+	"github.com/openshift/configure-goalert-operator/pkg/localmetrics"
 
 	corev1 "k8s.io/api/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -227,7 +229,7 @@ func (r *GoalertIntegrationReconciler) Reconcile(ctx context.Context, req ctrl.R
 func (r *GoalertIntegrationReconciler) authGoalert(ctx context.Context, username string, password string) (*http.Response, error) {
 
 	// Create authentication endpoint
-	goalertApiEndpoint := config.GoalertApiEndpointEnvVar
+	goalertApiEndpoint := os.Getenv(config.GoalertApiEndpointEnvVar)
 	authUrl := goalertApiEndpoint + "/api/v2/identity/providers/basic"
 
 	// Create form data to be sent in the request body


### PR DESCRIPTION
* fixes an issue where we are not fetching the GOALERT_ENDPOINT_URL from env vars and setting it to the literal string. This was causing the operator to crash

```
1.6972086990330393e+09	ERROR	Error sending HTTP request	{"controller": "goalertintegration", "controllerGroup": "goalert.managed.openshift.io", "controllerKind": "GoalertIntegration", "GoalertIntegration": {"name":"osd","namespace":"configure-goalert-operator"}, "namespace": "configure-goalert-operator", "name": "osd", "reconcileID": "3a64d4d1-49a8-4cca-a0d5-547a02d5068b", "controller": "goalertintegration", "error": "Post \"**GOALERT_ENDPOINT_URL**/api/v2/identity/providers/basic\": unsupported protocol scheme \"\""}
```
