### PR TITLE
Fix controller-runtime metrics server port conflict

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	goalertv1alpha1 "github.com/openshift/configure-goalert-operator/api/v1alpha1"
 	"github.com/openshift/configure-goalert-operator/controllers/goalertintegration"
@@ -72,7 +73,10 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 scheme,
+		Scheme: scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "7dc63a4f.managed.openshift.io",


### PR DESCRIPTION
## Problem

After merging PR #192 which upgraded to controller-runtime v0.19.0, the operator crashes on startup with CrashLoopBackOff due to a port conflict:

```
bind: address already in use
```

## Root Cause

controller-runtime v0.19.0 changed the metrics configuration API:
- **Old API** (v0.13.0): `MetricsBindAddress string` field in `ctrl.Options`
- **New API** (v0.19.0): `Metrics metricsserver.Options` struct in `ctrl.Options`

The upgrade didn't include the necessary configuration to disable the built-in metrics server. As a result, both controller-runtime's built-in server and operator-custom-metrics attempt to bind to port 8080, causing the crash.

## Solution

Configure the manager with `Metrics: metricsserver.Options{BindAddress: "0"}` to disable the controller-runtime built-in metrics server, as documented in AGENTS.md:

> The operator uses openshift/operator-custom-metrics for Prometheus metrics, NOT controller-runtime's built-in metrics server.

## Testing

Verified fix resolves the CrashLoopBackOff on production clusters.

## Related

- Continuation of #192 (controller-runtime v0.19.0 upgrade)