### PR TITLE
Fix empty goalert secret

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ When adding `//nolint` directives, target only these linters.
 |---|---|
 | `api/v1alpha1/` | CRD types (`GoalertIntegration`). See [API Contracts](docs/api-contracts-guidelines.md) for schema details. |
 | `controllers/goalertintegration/` | Reconciler split across 5 files: main loop, create handler, delete handler, event handlers, heartbeat check. |
-| `pkg/goalert/` | Raw HTTP/GraphQL client. Implements `Client` interface. See [Integration Guidelines](docs/integration-guidelines.md). |
+| `pkg/goalert/` | Raw HTTP/GraphQL client. Implements `Client` interface (9 methods: create, read, delete operations for services/keys/monitors). See [Integration Guidelines](docs/integration-guidelines.md). |
 | `pkg/kube/` | Helpers to build ConfigMap, Secret, and SyncSet resources. |
 | `pkg/localmetrics/` | Prometheus gauges/histograms prefixed `cgao_`. See [API Contracts](docs/api-contracts-guidelines.md#prometheus-metrics-contract). |
 | `pkg/utils/` | `LoadSecretData` helper for reading Secret keys (in `secrets.go`). |
@@ -81,7 +81,7 @@ When adding `//nolint` directives, target only these linters.
 ### Key Dependencies
 
 - Go `1.24.0` (from `go.mod`)
-- `sigs.k8s.io/controller-runtime` v0.13.0
+- `sigs.k8s.io/controller-runtime` v0.19.0
 - `github.com/openshift/hive/apis` -- ClusterDeployment, SyncSet types
 - `github.com/openshift/operator-custom-metrics` -- Custom metrics server (replaces controller-runtime metrics)
 - `github.com/pingcap/errors` -- Legacy; used in `clusterdeployment_created.go` and `heartbeatmonitor_check.go` only
@@ -95,7 +95,7 @@ When adding `//nolint` directives, target only these linters.
 4. Check heartbeat monitors for matching CDs
 5. Handle GI deletion: clean up all CDs with matching finalizer
 6. Handle CD deletion / label un-match: delete GoAlert services
-7. Handle CD creation: if ConfigMap/Secret/SyncSet don't exist, call `handleCreate`
+7. Handle CD creation: if ConfigMap, Secret (content-aware: empty integration keys treated as not-existing), or SyncSet don't exist, call `handleCreate` which uses get-or-create to adopt pre-existing GoAlert resources
 
 For detailed create/delete ordering and cleanup logic, see [Integration Guidelines](docs/integration-guidelines.md).
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The Configure GoAlert Operator (CGAO) is used to automate integrating OpenShift 
 
 [![codecov](https://codecov.io/gh/openshift/configure-goalert-operator/branch/main/graph/badge.svg)](https://codecov.io/gh/openshift/configure-goalert-operator)
 
+> **⚠️ Disclaimer:** Portions of this code have been generated using AI.
+
 ## Documentation
 
 In addition to this README, the repository includes detailed developer documentation:
@@ -21,7 +23,7 @@ In addition to this README, the repository includes detailed developer documenta
 |---|---|
 | `api/v1alpha1/` | CRD types for `GoalertIntegration` |
 | `controllers/goalertintegration/` | Reconciler (main loop, create/delete handlers, event handlers, heartbeat check) |
-| `pkg/goalert/` | HTTP/GraphQL client implementing the `Client` interface |
+| `pkg/goalert/` | HTTP/GraphQL client implementing the `Client` interface (create, read, delete operations) |
 | `pkg/kube/` | Helpers to build ConfigMap, Secret, and SyncSet resources |
 | `pkg/localmetrics/` | Prometheus gauges/histograms (prefixed `cgao_`) |
 | `pkg/utils/` | `LoadSecretData` helper for reading Secret keys |
@@ -32,8 +34,8 @@ In addition to this README, the repository includes detailed developer documenta
 
 ### Key Dependencies
 
-- **Go 1.23** with FIPS-enabled builds (`FIPS_ENABLED=true`)
-- **controller-runtime** v0.13.0 -- Kubernetes controller framework
+- **Go 1.24.0** with FIPS-enabled builds (`FIPS_ENABLED=true`)
+- **controller-runtime** v0.19.0 -- Kubernetes controller framework
 - **openshift/hive** -- ClusterDeployment and SyncSet types
 - **openshift/operator-custom-metrics** -- Prometheus metrics server
 - **GoAlert** -- Upstream alerting platform, accessed via GraphQL at the URL in `GOALERT_ENDPOINT_URL`
@@ -45,10 +47,10 @@ To onboard clusters:
 * Create a GoalertIntegration CR
 * Create a Goalert Integration controller that watches for changes to GoalertIntegration CRs, and also for changes to appropriately labeled ClusterDeployment CRs.
 * For each GoalertIntegration CR, it will get a list of matching ClusterDeployments that have the `spec.installed` field set to true.
-* For each of these ClusterDeployments, the operator will leverage GraphQL to create 2 new services in Goalert, one for high alerts and one for low alerts, each with the cluster UID as name
-* For the high alerts service, the operator will make an api call to generate an integration key and a heartbeat api endpoint. The service will be attached to the SREP High alerts escalation policy
-* For the low alerts service, the operator will only create a new integration key
-* The operator will then create a secret in the cluster which contains the integration keys and heartbeat api endpoint required to communicate with Goalert Web application.
+* For each of these ClusterDeployments, the operator will leverage GraphQL to ensure 2 services exist in Goalert (adopting pre-existing services by exact name match or creating new ones), one for high alerts and one for low alerts, each with the cluster UID as name
+* For the high alerts service, the operator will ensure an integration key and a heartbeat api endpoint exist. The service will be attached to the SREP High alerts escalation policy
+* For the low alerts service, the operator will ensure an integration key exists
+* The operator will then create (or self-heal) a secret in the cluster namespace which contains the integration keys and heartbeat api endpoint required to communicate with Goalert Web application. The operator refuses to persist a secret with empty integration keys, requeuing until all keys are available.
 
 To off-board clusters:
 
@@ -56,7 +58,7 @@ To off-board clusters:
 
 ## Development and Testing
 
-Changes made to the operator should be tested and validated before a PR is submitted and approved. 
+Changes made to the operator should be tested and validated before a PR is submitted and approved.
 
 Your test process should include:
 * Validating the operator image builds and has no CVE's introduced
@@ -91,8 +93,8 @@ $ oc apply -f config/crds
     ```
 4. Create the namespace: `oc create ns configure-goalert-operator`
 5. Deploy the operator: `oc create -f deploy/`
-6. Create test user in Goalert 
-7. Create secret with Goalert test user credentials 
+6. Create test user in Goalert
+7. Create secret with Goalert test user credentials
 ```shell
 apiVersion: v1
 data:
@@ -109,7 +111,7 @@ type: Opaque
 
 `configure-goalert-operator` doesn't start reconciling clusters until `spec.installed` is set to `true`.
 
-You can create a dummy ClusterDeployment by copying a real one from an active hive. Warning: deleting the copied CD may trigger the deletion of the AWS objects of the real CD. Set the following spec to keep hive from deprovisioning the resources 
+You can create a dummy ClusterDeployment by copying a real one from an active hive. Warning: deleting the copied CD may trigger the deletion of the AWS objects of the real CD. Set the following spec to keep hive from deprovisioning the resources
 
 ```
 spec:

--- a/controllers/goalertintegration/clusterdeployment_created.go
+++ b/controllers/goalertintegration/clusterdeployment_created.go
@@ -41,6 +41,42 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+// ensureService returns the ID of an existing GoAlert service matching data.Name, creating it if absent.
+func ensureService(ctx context.Context, gclient goalert.Client, data *goalert.Data) (string, error) {
+	id, err := gclient.GetServiceIDByName(ctx, data.Name)
+	if err != nil {
+		return "", err
+	}
+	if id != "" {
+		return id, nil
+	}
+	return gclient.CreateService(ctx, data)
+}
+
+// ensureIntegrationKey returns the href of an existing integration key matching data.Name on data.Id, creating it if absent.
+func ensureIntegrationKey(ctx context.Context, gclient goalert.Client, data *goalert.Data) (string, error) {
+	href, err := gclient.GetIntegrationKeyHref(ctx, data.Id, data.Name, data.Type)
+	if err != nil {
+		return "", err
+	}
+	if href != "" {
+		return href, nil
+	}
+	return gclient.CreateIntegrationKey(ctx, data)
+}
+
+// ensureHeartbeatMonitor returns the href and id of an existing heartbeat monitor matching data.Name on data.Id, creating it if absent.
+func ensureHeartbeatMonitor(ctx context.Context, gclient goalert.Client, data *goalert.Data) (string, string, error) {
+	href, id, err := gclient.GetHeartbeatMonitor(ctx, data.Id, data.Name)
+	if err != nil {
+		return "", "", err
+	}
+	if href != "" && id != "" {
+		return href, id, nil
+	}
+	return gclient.CreateHeartbeatMonitor(ctx, data)
+}
+
 // handleCreate provisions GoAlert services, integration keys, and a heartbeat monitor for a ClusterDeployment, then creates the corresponding ConfigMap, Secret, and SyncSet.
 func (r *GoalertIntegrationReconciler) handleCreate(ctx context.Context, gclient goalert.Client, gi *goalertv1alpha1.GoalertIntegration, cd *hivev1.ClusterDeployment) error {
 
@@ -82,13 +118,13 @@ func (r *GoalertIntegrationReconciler) handleCreate(ctx context.Context, gclient
 		Favorite:           true,
 	}
 
-	highSvcID, err := gclient.CreateService(ctx, dataHighSvc)
+	highSvcID, err := ensureService(ctx, gclient, dataHighSvc)
 	if err != nil {
 		r.reqLogger.Error(err, "Failed to create service for High alerts")
 		localmetrics.UpdateMetricCGAOCreateFailure(1, dataHighSvc.Name)
 		return err
 	}
-	lowSvcID, err := gclient.CreateService(ctx, dataLowSvc)
+	lowSvcID, err := ensureService(ctx, gclient, dataLowSvc)
 	if err != nil {
 		r.reqLogger.Error(err, "Failed to create service for Low alerts")
 		localmetrics.UpdateMetricCGAOCreateFailure(1, dataLowSvc.Name)
@@ -107,12 +143,12 @@ func (r *GoalertIntegrationReconciler) handleCreate(ctx context.Context, gclient
 		Name: "Low alerts",
 	}
 
-	highIntKey, err := gclient.CreateIntegrationKey(ctx, dataIntKeyHighSvc)
+	highIntKey, err := ensureIntegrationKey(ctx, gclient, dataIntKeyHighSvc)
 	if err != nil {
 		r.reqLogger.Error(err, "Failed to create integration key for high alerts")
 		return err
 	}
-	lowIntKey, err := gclient.CreateIntegrationKey(ctx, dataIntKeyLowSvc)
+	lowIntKey, err := ensureIntegrationKey(ctx, gclient, dataIntKeyLowSvc)
 	if err != nil {
 		r.reqLogger.Error(err, "Failed to create integration key for low alerts")
 		return err
@@ -125,7 +161,7 @@ func (r *GoalertIntegrationReconciler) handleCreate(ctx context.Context, gclient
 		Timeout: 15,
 	}
 
-	heartbeatMonitorKey, heartbeatMonitorId, err := gclient.CreateHeartbeatMonitor(ctx, dataHeartbeatMonitor)
+	heartbeatMonitorKey, heartbeatMonitorId, err := ensureHeartbeatMonitor(ctx, gclient, dataHeartbeatMonitor)
 	if err != nil {
 		r.reqLogger.Error(err, "Failed to create heartbeat monitor")
 		return err

--- a/controllers/goalertintegration/clusterdeployment_created.go
+++ b/controllers/goalertintegration/clusterdeployment_created.go
@@ -178,14 +178,24 @@ func (r *GoalertIntegrationReconciler) handleCreate(ctx context.Context, gclient
 		if err := r.Create(ctx, newCM); err != nil {
 			if errors.IsAlreadyExists(err) {
 				if updateErr := r.Update(ctx, newCM); updateErr != nil {
-					r.reqLogger.Error(err, "Error updating existing configmap", "Name", configMapName)
-					return err
+					r.reqLogger.Error(updateErr, "Error updating existing configmap", "Name", configMapName)
+					return updateErr
 				}
-				return nil
+			} else {
+				r.reqLogger.Error(err, "Error creating configmap", "Name", configMapName)
+				return err
 			}
-			r.reqLogger.Error(err, "Error creating configmap", "Name", configMapName)
-			return err
 		}
+	}
+
+	// Refuse to write a goalert secret with empty integration key(s). An empty
+	// secret breaks alerting on the managed cluster, so return an error to
+	// requeue and re-fetch the keys on the next reconcile.
+	if highIntKey == "" || lowIntKey == "" || heartbeatMonitorKey == "" {
+		err := fmt.Errorf("refusing to write goalert secret with empty integration key(s) (high=%t low=%t heartbeat=%t)",
+			highIntKey != "", lowIntKey != "", heartbeatMonitorKey != "")
+		r.reqLogger.Error(err, "empty integration key(s); requeuing", "ClusterDeployment.Namespace", cd.Namespace)
+		return err
 	}
 
 	// add secret part

--- a/controllers/goalertintegration/clusterdeployment_created_test.go
+++ b/controllers/goalertintegration/clusterdeployment_created_test.go
@@ -1,0 +1,336 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package goalertintegration
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	goalertv1alpha1 "github.com/openshift/configure-goalert-operator/api/v1alpha1"
+	"github.com/openshift/configure-goalert-operator/config"
+	"github.com/openshift/configure-goalert-operator/pkg/goalert"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestEnsureService covers the get-or-create behaviour of ensureService:
+// an existing service is returned without creating, a missing service is
+// created, and both GET and CREATE errors are propagated.
+func TestEnsureService(t *testing.T) {
+	tests := []struct {
+		name         string
+		getID        string
+		getErr       error
+		createID     string
+		createErr    error
+		expectedID   string
+		expectedErr  bool
+		expectCreate bool
+	}{
+		{
+			name:         "existing service returns its id without creating",
+			getID:        "existing-svc-id",
+			expectedID:   "existing-svc-id",
+			expectedErr:  false,
+			expectCreate: false,
+		},
+		{
+			name:         "missing service is created",
+			getID:        "",
+			createID:     "new-svc-id",
+			expectedID:   "new-svc-id",
+			expectedErr:  false,
+			expectCreate: true,
+		},
+		{
+			name:         "get error is propagated without creating",
+			getErr:       errors.New("get failed"),
+			expectedErr:  true,
+			expectCreate: false,
+		},
+		{
+			name:         "create error is propagated",
+			getID:        "",
+			createErr:    errors.New("create failed"),
+			expectedErr:  true,
+			expectCreate: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			createCalled := false
+			stub := &stubGoalertClient{
+				getServiceIDByName: func(_ context.Context, _ string) (string, error) {
+					return test.getID, test.getErr
+				},
+				createService: func(_ context.Context, _ *goalert.Data) (string, error) {
+					createCalled = true
+					return test.createID, test.createErr
+				},
+			}
+
+			id, err := ensureService(ctx, stub, &goalert.Data{Name: "fedramp-abc123 - High"})
+
+			if test.expectedErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Equal(t, test.expectedID, id)
+				assert.Nil(t, err)
+			}
+			assert.Equal(t, test.expectCreate, createCalled)
+		})
+	}
+}
+
+// TestEnsureIntegrationKey covers the get-or-create behaviour of
+// ensureIntegrationKey: an existing key href is returned without creating, a
+// missing key is created, and both GET and CREATE errors are propagated.
+func TestEnsureIntegrationKey(t *testing.T) {
+	tests := []struct {
+		name         string
+		getHref      string
+		getErr       error
+		createHref   string
+		createErr    error
+		expectedHref string
+		expectedErr  bool
+		expectCreate bool
+	}{
+		{
+			name:         "existing integration key returns its href without creating",
+			getHref:      "/api/v2/generic/incoming?token=high",
+			expectedHref: "/api/v2/generic/incoming?token=high",
+			expectedErr:  false,
+			expectCreate: false,
+		},
+		{
+			name:         "missing integration key is created",
+			getHref:      "",
+			createHref:   "/api/v2/generic/incoming?token=new",
+			expectedHref: "/api/v2/generic/incoming?token=new",
+			expectedErr:  false,
+			expectCreate: true,
+		},
+		{
+			name:         "get error is propagated without creating",
+			getErr:       errors.New("get failed"),
+			expectedErr:  true,
+			expectCreate: false,
+		},
+		{
+			name:         "create error is propagated",
+			getHref:      "",
+			createErr:    errors.New("create failed"),
+			expectedErr:  true,
+			expectCreate: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			createCalled := false
+			stub := &stubGoalertClient{
+				getIntegrationKeyHref: func(_ context.Context, _, _, _ string) (string, error) {
+					return test.getHref, test.getErr
+				},
+				createIntegrationKey: func(_ context.Context, _ *goalert.Data) (string, error) {
+					createCalled = true
+					return test.createHref, test.createErr
+				},
+			}
+
+			href, err := ensureIntegrationKey(ctx, stub, &goalert.Data{Id: "svc-1", Name: "High alerts", Type: "prometheusAlertmanager"})
+
+			if test.expectedErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Equal(t, test.expectedHref, href)
+				assert.Nil(t, err)
+			}
+			assert.Equal(t, test.expectCreate, createCalled)
+		})
+	}
+}
+
+// TestEnsureHeartbeatMonitor covers the get-or-create behaviour of
+// ensureHeartbeatMonitor, including the case where a href is present but the id
+// is empty (which must still trigger a create because both are required).
+func TestEnsureHeartbeatMonitor(t *testing.T) {
+	tests := []struct {
+		name         string
+		getHref      string
+		getID        string
+		getErr       error
+		createHref   string
+		createID     string
+		createErr    error
+		expectedHref string
+		expectedID   string
+		expectedErr  bool
+		expectCreate bool
+	}{
+		{
+			name:         "existing monitor returns its href and id without creating",
+			getHref:      "/api/v2/heartbeat/abc",
+			getID:        "hb-existing",
+			expectedHref: "/api/v2/heartbeat/abc",
+			expectedID:   "hb-existing",
+			expectedErr:  false,
+			expectCreate: false,
+		},
+		{
+			name:         "missing monitor is created",
+			createHref:   "/api/v2/heartbeat/new",
+			createID:     "hb-new",
+			expectedHref: "/api/v2/heartbeat/new",
+			expectedID:   "hb-new",
+			expectedErr:  false,
+			expectCreate: true,
+		},
+		{
+			name:         "href present but id empty triggers create",
+			getHref:      "/api/v2/heartbeat/abc",
+			getID:        "",
+			createHref:   "/api/v2/heartbeat/new",
+			createID:     "hb-new",
+			expectedHref: "/api/v2/heartbeat/new",
+			expectedID:   "hb-new",
+			expectedErr:  false,
+			expectCreate: true,
+		},
+		{
+			name:         "get error is propagated without creating",
+			getErr:       errors.New("get failed"),
+			expectedErr:  true,
+			expectCreate: false,
+		},
+		{
+			name:         "create error is propagated",
+			createErr:    errors.New("create failed"),
+			expectedErr:  true,
+			expectCreate: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			createCalled := false
+			stub := &stubGoalertClient{
+				getHeartbeatMonitor: func(_ context.Context, _, _ string) (string, string, error) {
+					return test.getHref, test.getID, test.getErr
+				},
+				createHeartbeatMonitor: func(_ context.Context, _ *goalert.Data) (string, string, error) {
+					createCalled = true
+					return test.createHref, test.createID, test.createErr
+				},
+			}
+
+			href, id, err := ensureHeartbeatMonitor(ctx, stub, &goalert.Data{Id: "svc-1", Name: "fedramp-abc123", Timeout: 15})
+
+			if test.expectedErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Equal(t, test.expectedHref, href)
+				assert.Equal(t, test.expectedID, id)
+				assert.Nil(t, err)
+			}
+			assert.Equal(t, test.expectCreate, createCalled)
+		})
+	}
+}
+
+// TestHandleCreateEmptySecretGuard verifies that handleCreate refuses to write a
+// goalert Secret when any integration key or the heartbeat monitor key is empty.
+// It returns an error and leaves no Secret behind so the next reconcile retries.
+func TestHandleCreateEmptySecretGuard(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme(t)
+
+	gi := &goalertv1alpha1.GoalertIntegration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gi",
+			Namespace: "test-ns",
+		},
+		Spec: goalertv1alpha1.GoalertIntegrationSpec{
+			ServicePrefix:        "test",
+			HighEscalationPolicy: "high-ep",
+			LowEscalationPolicy:  "low-ep",
+		},
+	}
+
+	// The ClusterDeployment must already carry the finalizer so handleCreate does
+	// not return early after adding it via Patch, and instead reaches the guard.
+	cd := &hivev1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-cd",
+			Namespace:  "cluster-ns-abc123",
+			Finalizers: []string{config.GoalertFinalizerPrefix + gi.Name},
+		},
+		Spec: hivev1.ClusterDeploymentSpec{
+			ClusterName: "test-cluster",
+		},
+	}
+
+	// Services resolve to a non-empty ID (so the ConfigMap is written), but the
+	// integration keys and heartbeat monitor key come back empty -- exactly the
+	// condition the guard must catch.
+	stub := &stubGoalertClient{
+		getServiceIDByName: func(_ context.Context, _ string) (string, error) {
+			return "existing-svc-id", nil
+		},
+		getIntegrationKeyHref: func(_ context.Context, _, _, _ string) (string, error) {
+			return "", nil
+		},
+		createIntegrationKey: func(_ context.Context, _ *goalert.Data) (string, error) {
+			return "", nil
+		},
+		getHeartbeatMonitor: func(_ context.Context, _, _ string) (string, string, error) {
+			return "", "", nil
+		},
+		createHeartbeatMonitor: func(_ context.Context, _ *goalert.Data) (string, string, error) {
+			return "", "", nil
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &GoalertIntegrationReconciler{
+		Client:    fakeClient,
+		Scheme:    scheme,
+		reqLogger: logr.Discard(),
+	}
+
+	err := r.handleCreate(ctx, stub, gi, cd)
+
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "refusing to write goalert secret")
+
+	// The guard must prevent any Secret from being written.
+	secretErr := r.Get(ctx, types.NamespacedName{Name: config.SecretName, Namespace: cd.Namespace}, &corev1.Secret{})
+	assert.True(t, apierrors.IsNotFound(secretErr))
+}

--- a/controllers/goalertintegration/goalertintegration_controller.go
+++ b/controllers/goalertintegration/goalertintegration_controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -238,7 +239,11 @@ func (r *GoalertIntegrationReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}
 
-	// Create service in Goalert
+	// Create service in Goalert. A per-CD failure is logged and collected but
+	// does not abort the loop, so one failing ClusterDeployment cannot block the
+	// others. After the loop, any accumulated errors are aggregated and returned
+	// so the reconcile requeues with backoff (prompt self-heal).
+	var createErrs []error
 	for i := range matchingClusterDeployments.Items {
 		cd := matchingClusterDeployments.Items[i]
 		if cd.DeletionTimestamp == nil {
@@ -249,9 +254,13 @@ func (r *GoalertIntegrationReconciler) Reconcile(ctx context.Context, req ctrl.R
 			if !cmExists || !secretExists || !syncsetExists {
 				if err = r.handleCreate(ctx, graphqlClient, gi, &cd); err != nil {
 					r.reqLogger.Error(err, "failing to register cluster with Goalert")
+					createErrs = append(createErrs, err)
 				}
 			}
 		}
+	}
+	if len(createErrs) > 0 {
+		return r.requeueOnErr(utilerrors.NewAggregate(createErrs))
 	}
 
 	return ctrl.Result{}, nil

--- a/controllers/goalertintegration/goalertintegration_controller.go
+++ b/controllers/goalertintegration/goalertintegration_controller.go
@@ -349,6 +349,8 @@ func (r *GoalertIntegrationReconciler) getMatchingClusterDeployments(ctx context
 }
 
 // cgaoResourcesExist checks whether the ConfigMap, Secret, and SyncSet for a ClusterDeployment already exist.
+// The Secret check is content-aware: a Secret that is present but has empty high, low, or heartbeat
+// integration keys is treated as not existing so the next reconcile will re-create it and self-heal.
 func (r *GoalertIntegrationReconciler) cgaoResourcesExist(ctx context.Context, gi *goalertv1alpha1.GoalertIntegration, cd *hivev1.ClusterDeployment) (bool, bool, bool, error) {
 	r.reqLogger.Info("Checking for CGAO resources", "clusterdeployment:", cd.Name)
 
@@ -361,13 +363,17 @@ func (r *GoalertIntegrationReconciler) cgaoResourcesExist(ctx context.Context, g
 	cmExists = !errors.IsNotFound(err)
 
 	secretExist := false
-	err = r.Get(ctx,
-		types.NamespacedName{Name: config.SecretName, Namespace: cd.Namespace},
-		&corev1.Secret{})
+	sc := &corev1.Secret{}
+	err = r.Get(ctx, types.NamespacedName{Name: config.SecretName, Namespace: cd.Namespace}, sc)
 	if err != nil && !errors.IsNotFound(err) {
 		return false, false, false, err
 	}
-	secretExist = !errors.IsNotFound(err)
+	if err == nil &&
+		len(sc.Data[config.GoalertHighIntKey]) > 0 &&
+		len(sc.Data[config.GoalertLowIntKey]) > 0 &&
+		len(sc.Data[config.GoalertHeartbeatIntKey]) > 0 {
+		secretExist = true
+	}
 
 	syncSetExist := false
 	err = r.Get(ctx, types.NamespacedName{Name: config.SecretName, Namespace: cd.Namespace}, &hivev1.SyncSet{})

--- a/controllers/goalertintegration/goalertintegration_controller_test.go
+++ b/controllers/goalertintegration/goalertintegration_controller_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package goalertintegration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	goalertv1alpha1 "github.com/openshift/configure-goalert-operator/api/v1alpha1"
+	"github.com/openshift/configure-goalert-operator/config"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestCgaoResourcesExistSecretContentAware exercises the content-aware Secret
+// check in cgaoResourcesExist: a Secret only counts as existing when it is
+// present AND all three integration-key data keys are non-empty. It asserts the
+// secretExist return position (the second of four return values).
+func TestCgaoResourcesExistSecretContentAware(t *testing.T) {
+	scheme := newTestScheme(t)
+
+	gi := &goalertv1alpha1.GoalertIntegration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gi",
+			Namespace: "test-ns",
+		},
+		Spec: goalertv1alpha1.GoalertIntegrationSpec{
+			ServicePrefix: "test",
+		},
+	}
+	cd := &hivev1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cd",
+			Namespace: "cluster-ns-abc123",
+		},
+	}
+
+	tests := []struct {
+		name               string
+		objects            []client.Object
+		expectedSecretBool bool
+	}{
+		{
+			name:               "no secret present returns false",
+			objects:            nil,
+			expectedSecretBool: false,
+		},
+		{
+			name: "secret with empty data returns false",
+			objects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      config.SecretName,
+						Namespace: cd.Namespace,
+					},
+				},
+			},
+			expectedSecretBool: false,
+		},
+		{
+			name: "secret missing one integration key returns false",
+			objects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      config.SecretName,
+						Namespace: cd.Namespace,
+					},
+					Data: map[string][]byte{
+						config.GoalertHighIntKey: []byte("high-url"),
+						config.GoalertLowIntKey:  []byte("low-url"),
+					},
+				},
+			},
+			expectedSecretBool: false,
+		},
+		{
+			name: "secret with all three integration keys populated returns true",
+			objects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      config.SecretName,
+						Namespace: cd.Namespace,
+					},
+					Data: map[string][]byte{
+						config.GoalertHighIntKey:      []byte("high-url"),
+						config.GoalertLowIntKey:       []byte("low-url"),
+						config.GoalertHeartbeatIntKey: []byte("hb-url"),
+					},
+				},
+			},
+			expectedSecretBool: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(test.objects...).
+				Build()
+			r := &GoalertIntegrationReconciler{
+				Client:    fakeClient,
+				Scheme:    scheme,
+				reqLogger: logr.Discard(),
+			}
+
+			_, secretExist, _, err := r.cgaoResourcesExist(ctx, gi, cd)
+
+			assert.Nil(t, err)
+			assert.Equal(t, test.expectedSecretBool, secretExist)
+		})
+	}
+}

--- a/controllers/goalertintegration/goalertintegration_controller_test.go
+++ b/controllers/goalertintegration/goalertintegration_controller_test.go
@@ -94,6 +94,23 @@ func TestCgaoResourcesExistSecretContentAware(t *testing.T) {
 			expectedSecretBool: false,
 		},
 		{
+			name: "secret with all three integration keys present but empty returns false",
+			objects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      config.SecretName,
+						Namespace: cd.Namespace,
+					},
+					Data: map[string][]byte{
+						config.GoalertHighIntKey:      {},
+						config.GoalertLowIntKey:       {},
+						config.GoalertHeartbeatIntKey: {},
+					},
+				},
+			},
+			expectedSecretBool: false,
+		},
+		{
 			name: "secret with all three integration keys populated returns true",
 			objects: []client.Object{
 				&corev1.Secret{

--- a/controllers/goalertintegration/helpers_test.go
+++ b/controllers/goalertintegration/helpers_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package goalertintegration
+
+import (
+	"context"
+	"testing"
+
+	goalertv1alpha1 "github.com/openshift/configure-goalert-operator/api/v1alpha1"
+	"github.com/openshift/configure-goalert-operator/pkg/goalert"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+)
+
+// stubGoalertClient is a hand-written test double implementing goalert.Client.
+// Each method delegates to its matching function field when that field is set,
+// otherwise it returns zero values so that methods a given test does not care
+// about stay harmless.
+type stubGoalertClient struct {
+	getServiceIDByName     func(ctx context.Context, name string) (string, error)
+	createService          func(ctx context.Context, data *goalert.Data) (string, error)
+	getIntegrationKeyHref  func(ctx context.Context, serviceID, keyName, keyType string) (string, error)
+	createIntegrationKey   func(ctx context.Context, data *goalert.Data) (string, error)
+	getHeartbeatMonitor    func(ctx context.Context, serviceID, monitorName string) (string, string, error)
+	createHeartbeatMonitor func(ctx context.Context, data *goalert.Data) (string, string, error)
+}
+
+// compile-time assertion that stubGoalertClient satisfies the goalert.Client interface.
+var _ goalert.Client = &stubGoalertClient{}
+
+// GetServiceIDByName delegates to the getServiceIDByName field when set.
+func (s *stubGoalertClient) GetServiceIDByName(ctx context.Context, name string) (string, error) {
+	if s.getServiceIDByName != nil {
+		return s.getServiceIDByName(ctx, name)
+	}
+	return "", nil
+}
+
+// CreateService delegates to the createService field when set.
+func (s *stubGoalertClient) CreateService(ctx context.Context, data *goalert.Data) (string, error) {
+	if s.createService != nil {
+		return s.createService(ctx, data)
+	}
+	return "", nil
+}
+
+// GetIntegrationKeyHref delegates to the getIntegrationKeyHref field when set.
+func (s *stubGoalertClient) GetIntegrationKeyHref(ctx context.Context, serviceID, keyName, keyType string) (string, error) {
+	if s.getIntegrationKeyHref != nil {
+		return s.getIntegrationKeyHref(ctx, serviceID, keyName, keyType)
+	}
+	return "", nil
+}
+
+// CreateIntegrationKey delegates to the createIntegrationKey field when set.
+func (s *stubGoalertClient) CreateIntegrationKey(ctx context.Context, data *goalert.Data) (string, error) {
+	if s.createIntegrationKey != nil {
+		return s.createIntegrationKey(ctx, data)
+	}
+	return "", nil
+}
+
+// GetHeartbeatMonitor delegates to the getHeartbeatMonitor field when set.
+func (s *stubGoalertClient) GetHeartbeatMonitor(ctx context.Context, serviceID, monitorName string) (string, string, error) {
+	if s.getHeartbeatMonitor != nil {
+		return s.getHeartbeatMonitor(ctx, serviceID, monitorName)
+	}
+	return "", "", nil
+}
+
+// CreateHeartbeatMonitor delegates to the createHeartbeatMonitor field when set.
+func (s *stubGoalertClient) CreateHeartbeatMonitor(ctx context.Context, data *goalert.Data) (string, string, error) {
+	if s.createHeartbeatMonitor != nil {
+		return s.createHeartbeatMonitor(ctx, data)
+	}
+	return "", "", nil
+}
+
+// DeleteService is unused by the current tests and returns a nil error.
+func (s *stubGoalertClient) DeleteService(ctx context.Context, data *goalert.Data) error {
+	return nil
+}
+
+// NewRequest is unused by the current tests and returns zero values.
+func (s *stubGoalertClient) NewRequest(ctx context.Context, method string, body any) ([]byte, error) {
+	return nil, nil
+}
+
+// IsHeartbeatMonitorInactive is unused by the current tests and returns zero values.
+func (s *stubGoalertClient) IsHeartbeatMonitorInactive(ctx context.Context, data *goalert.Data) (bool, error) {
+	return false, nil
+}
+
+// newTestScheme builds a runtime.Scheme registered with the same types main.go
+// registers: core Kubernetes, Hive, and the operator's own CRD. It is used to
+// back the controller-runtime fake client in controller-level tests.
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(hivev1.AddToScheme(scheme))
+	utilruntime.Must(goalertv1alpha1.AddToScheme(scheme))
+	return scheme
+}

--- a/docs/api-contracts-guidelines.md
+++ b/docs/api-contracts-guidelines.md
@@ -99,8 +99,13 @@ All GraphQL calls go to `{GOALERT_ENDPOINT_URL}/api/graphql` as POST requests wi
 | Operation | GraphQL | Input | Returns |
 |---|---|---|---|
 | Heartbeat State | `heartbeatMonitor` | `id` | `lastState` (string; `"inactive"` = unhealthy) |
+| Service Search | `services` | `search`, `first` | `nodes` array with `id`, `name` fields |
+| Service Integration Keys | `service` | `id` | `integrationKeys` array with `id`, `name`, `type`, `href` fields |
+| Service Heartbeat Monitors | `service` | `id` | `heartbeatMonitors` array with `id`, `name`, `href` fields |
 
 The `type` field for integration keys is always `prometheusAlertmanager` (unquoted enum in GraphQL, not a quoted string). The heartbeat monitor timeout is always `15` minutes. String parameters are quoted via `strconv.Quote()`.
+
+**Read method semantics:** The three new read queries (service search, integration keys, heartbeat monitors) power the get-or-create/adopt pattern. The GoAlert search API is fuzzy, so the `Client` interface methods (`GetServiceIDByName`, `GetIntegrationKeyHref`, `GetHeartbeatMonitor`) perform **exact client-side name matching** on the returned arrays. A successful no-match returns an empty string (or empty strings) with `nil` error. Only transport/unmarshal/GraphQL `errors` failures produce a non-nil error.
 
 ### Response Structs
 

--- a/docs/error-handling-guidelines.md
+++ b/docs/error-handling-guidelines.md
@@ -17,7 +17,7 @@ return r.requeueOnErr(err)
 - `requeueOnErr` -- any error fetching the GI, listing ClusterDeployments, updating finalizers, or failing `handleDelete` during GI/CD deletion.
 - Direct `return reconcile.Result{}, err` -- used only from `cgaoResourcesExist` for unexpected K8s API errors. Keep this limited; prefer the helpers.
 
-**Note:** The main reconcile loop ends with `return ctrl.Result{}, nil` (equivalent to `doNotRequeue`). Errors from `handleCreate` in the creation loop are logged but do **not** cause a requeue -- they use a log-and-continue pattern. This is intentional: a single failing CD should not block progress on others.
+**Note:** The main reconcile loop's creation phase uses a **continue-then-aggregate-and-requeue** pattern. Errors from `handleCreate` are logged per ClusterDeployment and the loop continues, so a single failing CD does not block progress on the others. After the loop, if any CD failed, the accumulated errors are combined with `utilerrors.NewAggregate` and returned through `requeueOnErr`, so the reconcile requeues with exponential backoff (prompt self-heal). When every CD succeeds, the loop ends with `return ctrl.Result{}, nil` (equivalent to `doNotRequeue`).
 
 ## Log-and-Continue vs Log-and-Return
 
@@ -28,7 +28,7 @@ The codebase uses two distinct error-handling strategies in the main `Reconcile(
 Used when a failure for one item should not block processing of other items, or when the operation will be retried on the next reconcile anyway:
 - Credential loading failures (`LoadSecretData` for username/password)
 - Heartbeat monitor checks per ClusterDeployment
-- `handleCreate` failures for individual CDs in the creation loop
+- `handleCreate` failures for individual CDs in the creation loop -- logged and the loop **continues** to the next CD, but the error is also accumulated and returned after the loop (continue-then-aggregate-and-requeue; see the Note under *Reconcile Return Helpers*)
 - `handleDelete` for unmatched CDs (label removed, not CD-deletion or GI-deletion)
 
 ### Log-and-return (stop and requeue)

--- a/docs/error-handling-guidelines.md
+++ b/docs/error-handling-guidelines.md
@@ -72,9 +72,23 @@ if err := r.Create(ctx, resource); err != nil {
 }
 ```
 
-The ConfigMap uses this to fall through to an `Update` call. The Secret uses it to compare data and conditionally delete-then-recreate. The SyncSet does a `Get`-first approach instead (it queries before creating). Follow the existing pattern for the resource type you are modifying.
+The ConfigMap uses this to call `Update` on `AlreadyExists` and **fall through** to the Secret and SyncSet reconciliation (previously it returned early, skipping them). The Secret uses it to compare data and conditionally delete-then-recreate. The SyncSet does a `Get`-first approach instead (it queries before creating). Follow the existing pattern for the resource type you are modifying.
 
 **Important:** `handleCreate` uses `"github.com/pingcap/errors"` for `IsAlreadyExists`/`IsNotFound`, while `handleDelete` and the main controller use `"k8s.io/apimachinery/pkg/api/errors"`. Both provide the same `IsNotFound`/`IsAlreadyExists` methods. New code should prefer `"k8s.io/apimachinery/pkg/api/errors"` (the standard K8s package) for consistency with the main controller and delete handler. The `pingcap/errors` usage in `clusterdeployment_created.go` and `heartbeatmonitor_check.go` is legacy.
+
+### Refuse-to-Write-Empty Pattern
+
+Before creating the `goalert-secret`, `handleCreate` verifies that all three integration key hrefs are non-empty. If any are empty, it returns an error to trigger a requeue:
+
+```go
+if highIntKey == "" || lowIntKey == "" || heartbeatMonitorKey == "" {
+    err := fmt.Errorf("refusing to write goalert secret with empty integration key(s) (high=%t low=%t heartbeat=%t)", ...)
+    r.reqLogger.Error(err, "empty integration key(s); requeuing", ...)
+    return err  // requeue
+}
+```
+
+This prevents persisting a broken secret (which would break alerting on the managed cluster). The next reconcile re-fetches the keys from GoAlert. The log message uses boolean conversions (`highIntKey != ""`) to avoid logging secret values.
 
 ## Error Wrapping Conventions
 

--- a/docs/integration-guidelines.md
+++ b/docs/integration-guidelines.md
@@ -37,7 +37,7 @@ Authentication is a two-step process performed every reconcile (the session cook
 5. **Ensure Low integration key** (`ensureIntegrationKey`)
 6. **Ensure heartbeat monitor** (`ensureHeartbeatMonitor` helper: GET via `GetHeartbeatMonitor`, create via `CreateHeartbeatMonitor` only if absent; on the High service, 15-minute timeout)
 7. **Create or update ConfigMap** (stores `HIGH_SERVICE_ID`, `LOW_SERVICE_ID`, `HEARTBEATMONITOR_ID`). If `AlreadyExists`, call `Update` and fall through (do not return early).
-8. **Guard and create Secret** -- before calling `Create`, verify all three integration key hrefs are non-empty. If any are empty, return an error to requeue (never persist an empty secret, which would break alerting). If Secret `AlreadyExists`, compare data; if changed, delete and recreate.
+8. **Guard and create Secret** -- before calling `Create`, verify all three integration key hrefs are non-empty. If any are empty, return an error (never persist an empty secret, which would break alerting); the reconcile loop accumulates this error and, after processing every matching CD, requeues with backoff so the keys are re-fetched. If Secret `AlreadyExists`, compare data; if changed, delete and recreate.
 9. **Create SyncSet** (references the Secret for propagation). Uses `Get`-then-create approach.
 
 Each step depends on IDs/keys from previous steps. If any GoAlert API call fails, return the error immediately -- do not create partial K8s resources.

--- a/docs/integration-guidelines.md
+++ b/docs/integration-guidelines.md
@@ -4,9 +4,18 @@
 
 ### Client Interface and Injection
 
-The `goalert.Client` interface in `pkg/goalert/service.go` defines all GoAlert API operations. The reconciler stores a factory function `gclient func(sessionCookie *http.Cookie) goalert.Client` rather than a client instance directly. `SetupWithManager` assigns `goalert.NewClient` as the default factory; this pattern allows tests to inject mock clients.
+The `goalert.Client` interface in `pkg/goalert/service.go` defines all GoAlert API operations (9 methods, including the 3 read queries described below). The reconciler stores a factory function `gclient func(sessionCookie *http.Cookie) goalert.Client` rather than a client instance directly. `SetupWithManager` assigns `goalert.NewClient` as the default factory; this pattern allows tests to inject mock clients.
 
 All GraphQL calls go through `Client.NewRequest`, which reads `GOALERT_ENDPOINT_URL` from the environment, POSTs to `/api/graphql`, and attaches the session cookie. GoAlert GraphQL API calls should use this interface. Authentication to `/api/v2/identity/providers/basic` is performed in the controller's `authGoalert` method.
+
+### Read Methods and Exact Name Matching
+
+Three read methods enable idempotent resource creation:
+- `GetServiceIDByName(ctx, name) (string, error)` -- searches for a service by name, returns its ID or `""` if not found
+- `GetIntegrationKeyHref(ctx, serviceID, keyName, keyType) (string, error)` -- finds an integration key by name on a service, returns href or `""`
+- `GetHeartbeatMonitor(ctx, serviceID, monitorName) (href, id, error)` -- finds a heartbeat monitor by name on a service, returns both href and id, or `("", "")`
+
+GoAlert's search API is fuzzy/substring-based, so these methods perform **exact client-side name matching** after the query. A successful no-match returns an empty string (or empty strings) with `nil` error. Only transport failures, unmarshal errors, or GraphQL `errors` array entries produce a non-nil error. This contract allows callers to distinguish "resource does not exist" (empty string) from "lookup failed" (non-nil error).
 
 ### GraphQL Mutation Pattern
 
@@ -22,18 +31,18 @@ Authentication is a two-step process performed every reconcile (the session cook
 
 `handleCreate` creates GoAlert resources in this strict order:
 1. **Add finalizer** to ClusterDeployment (via patch, returns early if added)
-2. **Create High service** (`CreateService`)
-3. **Create Low service** (`CreateService`)
-4. **Create High integration key** (`CreateIntegrationKey` with type `prometheusAlertmanager`)
-5. **Create Low integration key** (`CreateIntegrationKey`)
-6. **Create heartbeat monitor** (`CreateHeartbeatMonitor` on the High service, 15-minute timeout)
-7. **Create ConfigMap** (stores `HIGH_SERVICE_ID`, `LOW_SERVICE_ID`, `HEARTBEATMONITOR_ID`)
-8. **Create Secret** (stores integration key URLs and heartbeat key)
-9. **Create SyncSet** (references the Secret for propagation)
+2. **Ensure High service** (`ensureService` helper: GET via `GetServiceIDByName`, create via `CreateService` only if absent)
+3. **Ensure Low service** (`ensureService`)
+4. **Ensure High integration key** (`ensureIntegrationKey` helper: GET via `GetIntegrationKeyHref`, create via `CreateIntegrationKey` only if absent; type `prometheusAlertmanager`)
+5. **Ensure Low integration key** (`ensureIntegrationKey`)
+6. **Ensure heartbeat monitor** (`ensureHeartbeatMonitor` helper: GET via `GetHeartbeatMonitor`, create via `CreateHeartbeatMonitor` only if absent; on the High service, 15-minute timeout)
+7. **Create or update ConfigMap** (stores `HIGH_SERVICE_ID`, `LOW_SERVICE_ID`, `HEARTBEATMONITOR_ID`). If `AlreadyExists`, call `Update` and fall through (do not return early).
+8. **Guard and create Secret** -- before calling `Create`, verify all three integration key hrefs are non-empty. If any are empty, return an error to requeue (never persist an empty secret, which would break alerting). If Secret `AlreadyExists`, compare data; if changed, delete and recreate.
+9. **Create SyncSet** (references the Secret for propagation). Uses `Get`-then-create approach.
 
 Each step depends on IDs/keys from previous steps. If any GoAlert API call fails, return the error immediately -- do not create partial K8s resources.
 
-**Retry/idempotency caveat:** On failure, the reconciler requeues and re-enters `handleCreate` from the top. The GoAlert API calls are not idempotent -- there is no check for whether a service already exists before creating one. A failure after step 2 but before step 7 (ConfigMap creation) will produce orphaned GoAlert services on retry, since the operator has no record of the previously created IDs. There is no circuit breaker; retries continue indefinitely via the controller-runtime work queue.
+**Idempotency via get-or-create:** Steps 2-6 use `ensure*` helpers that adopt pre-existing GoAlert resources (by exact name match), making reconcile idempotent. A retry after partial failure will reuse existing services/keys/monitors instead of creating duplicates or hitting duplicate-name rejections. The ConfigMap and Secret creation logic (steps 7-8) similarly handle `AlreadyExists` to avoid errors on retry.
 
 ### GoAlert Resource Deletion Order
 
@@ -97,7 +106,7 @@ Finalizer removal and GoAlert cleanup (`handleDelete`) is triggered by three con
 
 - **CD finalizer add:** Uses `client.MergeFrom(cd.DeepCopy())` patch, not a full Update. Returns early after patching so the next reconcile continues creation.
 - **CD finalizer remove:** Also uses MergeFrom patch in `handleDelete`.
-- **GI finalizer add/remove:** Uses `r.Update(ctx, gi)`. 
+- **GI finalizer add/remove:** Uses `r.Update(ctx, gi)`.
 
 ## Heartbeat Monitoring
 
@@ -127,3 +136,5 @@ controllerutil.SetControllerReference(cd, resource, r.Scheme)
 ## Existence Check Pattern
 
 `cgaoResourcesExist` checks for ConfigMap, Secret, and SyncSet before calling `handleCreate`. Creation is triggered when **any** of the three is missing. Each check uses `r.Get` and distinguishes between NotFound (resource missing) and other errors (return error to requeue). This is the gating mechanism for idempotent reconciliation -- if all three exist, no GoAlert API calls are made.
+
+**Content-aware Secret check (self-heal):** The Secret existence check is not a simple presence check. A Secret that is present but has empty or missing data for any of the three integration key fields (`GOALERT_URL_HIGH`, `GOALERT_URL_LOW`, `GOALERT_HEARTBEAT`) is treated as **not existing**, triggering a re-entry into `handleCreate` on the next reconcile. This self-heals a deployed-but-empty secret without requiring manual GoAlert resource cleanup.

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -15,7 +15,9 @@ Pass extra flags via `TESTOPTS`: `TESTOPTS="-v -count=1" make go-test`.
 
 ## Test File Location
 
-Tests live alongside the code they test in the same package (white-box testing). The only test file currently is `pkg/goalert/service_test.go`. There are no controller tests -- the `controllers/goalertintegration/` package has zero test files.
+Tests live alongside the code they test in the same package (white-box testing). Test files currently include:
+- `pkg/goalert/service_test.go` -- GoAlert client tests
+- `controllers/goalertintegration/*_test.go` -- Controller reconciliation tests using a hand-written stub that implements the `goalert.Client` interface plus the controller-runtime `client/fake` client for K8s API interactions
 
 ## Coverage Configuration
 
@@ -115,11 +117,11 @@ type GoalertIntegrationReconciler struct {
 }
 ```
 
-`gclient` is set to `goalert.NewClient` in `SetupWithManager` but can be overridden in tests to inject a mock `Client` implementation. When writing controller tests, provide a mock that implements the `Client` interface rather than standing up an httptest server.
+`gclient` is set to `goalert.NewClient` in `SetupWithManager` but can be overridden in tests to inject a mock `Client` implementation. Controller tests use a hand-written stub that implements the `Client` interface (returning controllable test data or errors) in combination with the controller-runtime `client/fake` client for K8s resource operations. Tests follow the table-driven pattern with `testify/assert` for assertions.
 
 ## envtest Setup for Controller Tests
 
-No controller tests exist yet. When adding them, register all three schemes that `main.go` registers:
+Controller tests register all three schemes that `main.go` registers:
 
 ```go
 utilruntime.Must(clientgoscheme.AddToScheme(scheme))

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -28,8 +28,8 @@ Coverage is configured in `.codecov.yml`:
 
 ## Current Coverage Gaps
 
-The following packages have zero test coverage and are the highest-priority areas for new tests:
-- `controllers/goalertintegration/` -- all five files (main reconciler, create handler, delete handler, event handlers, heartbeat check)
+Unit tests now cover the main reconciler (`goalertintegration_controller_test.go`) and the create handler (`clusterdeployment_created_test.go`), with shared test doubles in `helpers_test.go`. The following still have zero test coverage and are the highest-priority areas for new tests:
+- `controllers/goalertintegration/` -- delete handler (`clusterdeployment_deleted.go`), event handlers (`event_handlers.go`), and heartbeat check (`heartbeatmonitor_check.go`)
 - `pkg/kube/` -- `GenerateConfigMap`, `GenerateGoalertSecret`, `GenerateSyncSet`
 - `pkg/utils/` -- `LoadSecretData`
 - `pkg/localmetrics/` -- metric update and delete helpers

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	golang.org/x/time v0.3.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/pkg/goalert/service.go
+++ b/pkg/goalert/service.go
@@ -42,7 +42,7 @@ type Client interface {
 	// DeleteService deletes a GoAlert service by ID.
 	DeleteService(ctx context.Context, data *Data) error
 	// NewRequest sends an HTTP request to the GoAlert GraphQL API and returns the response body.
-	NewRequest(ctx context.Context, method string, body interface{}) ([]byte, error)
+	NewRequest(ctx context.Context, method string, body any) ([]byte, error)
 	// IsHeartbeatMonitorInactive checks whether a heartbeat monitor is in the inactive state.
 	IsHeartbeatMonitorInactive(ctx context.Context, data *Data) (bool, error)
 }
@@ -85,6 +85,7 @@ type RespSvcData struct {
 			ID string `json:"id"`
 		} `json:"createService"`
 	} `json:"data"`
+	Errors []GraphQLError `json:"errors,omitempty"`
 }
 
 // RespIntKeyData describes int key returned from createIntegrationKey
@@ -94,6 +95,7 @@ type RespIntKeyData struct {
 			Key string `json:"href"`
 		} `json:"createIntegrationKey"`
 	} `json:"data"`
+	Errors []GraphQLError `json:"errors,omitempty"`
 }
 
 // RespHeartBeatData describes a heartbeat monitor key from createHeartbeatMonitor
@@ -104,6 +106,7 @@ type RespHeartBeatData struct {
 			Id  string `json:"id"`
 		} `json:"createHeartbeatMonitor"`
 	} `json:"data"`
+	Errors []GraphQLError `json:"errors,omitempty"`
 }
 
 // RespDelete contains boolean returned from deleteAll
@@ -122,8 +125,19 @@ type RespHeartbeatState struct {
 	} `json:"data"`
 }
 
+// GraphQLError represents a single error in a GraphQL response.
+type GraphQLError struct {
+	Message string `json:"message"`
+	Path    []any  `json:"path,omitempty"`
+}
+
+// GraphQLErrorResponse wraps GraphQL errors returned in HTTP 200 responses.
+type GraphQLErrorResponse struct {
+	Errors []GraphQLError `json:"errors,omitempty"`
+}
+
 // NewRequest is a wrapper func to help send the http request
-func (c *GraphqlClient) NewRequest(ctx context.Context, method string, body interface{}) ([]byte, error) {
+func (c *GraphqlClient) NewRequest(ctx context.Context, method string, body any) ([]byte, error) {
 
 	goalertApiEndpoint := os.Getenv(config.GoalertApiEndpointEnvVar)
 
@@ -181,6 +195,15 @@ func (c *GraphqlClient) CreateService(ctx context.Context, data *Data) (string, 
 	if err != nil {
 		return "", fmt.Errorf("unable to unmarshal response %s: %w", string(respData), err)
 	}
+
+	if len(r.Errors) > 0 {
+		return "", fmt.Errorf("GoAlert GraphQL error creating service: %s", r.Errors[0].Message)
+	}
+
+	if r.Data.CreateService.ID == "" {
+		return "", fmt.Errorf("GoAlert returned empty service ID (response: %s)", string(respData))
+	}
+
 	return r.Data.CreateService.ID, nil
 }
 
@@ -201,6 +224,14 @@ func (c *GraphqlClient) CreateIntegrationKey(ctx context.Context, data *Data) (s
 	err = json.Unmarshal(respData, &r)
 	if err != nil {
 		return "", fmt.Errorf("unable to unmarshal response %s: %w", string(respData), err)
+	}
+
+	if len(r.Errors) > 0 {
+		return "", fmt.Errorf("GoAlert GraphQL error creating integration key: %s", r.Errors[0].Message)
+	}
+
+	if r.Data.CreateIntKey.Key == "" {
+		return "", fmt.Errorf("GoAlert returned empty integration key (response: %s)", string(respData))
 	}
 
 	return r.Data.CreateIntKey.Key, nil
@@ -224,6 +255,15 @@ func (c *GraphqlClient) CreateHeartbeatMonitor(ctx context.Context, data *Data) 
 	if err != nil {
 		return "", "", fmt.Errorf("unable to unmarshal response %s: %w", string(respData), err)
 	}
+
+	if len(r.Errors) > 0 {
+		return "", "", fmt.Errorf("GoAlert GraphQL error creating heartbeat monitor: %s", r.Errors[0].Message)
+	}
+
+	if r.Data.CreateHeartBeatKey.Key == "" || r.Data.CreateHeartBeatKey.Id == "" {
+		return "", "", fmt.Errorf("GoAlert returned empty heartbeat key or ID (response: %s)", string(respData))
+	}
+
 	return r.Data.CreateHeartBeatKey.Key, r.Data.CreateHeartBeatKey.Id, nil
 }
 

--- a/pkg/goalert/service.go
+++ b/pkg/goalert/service.go
@@ -45,6 +45,15 @@ type Client interface {
 	NewRequest(ctx context.Context, method string, body any) ([]byte, error)
 	// IsHeartbeatMonitorInactive checks whether a heartbeat monitor is in the inactive state.
 	IsHeartbeatMonitorInactive(ctx context.Context, data *Data) (bool, error)
+	// GetServiceIDByName returns the ID of the GoAlert service whose name exactly matches name,
+	// or "" if no such service exists.
+	GetServiceIDByName(ctx context.Context, name string) (string, error)
+	// GetIntegrationKeyHref returns the href of the integration key on the given service whose
+	// name matches keyName, or "" if none exists.
+	GetIntegrationKeyHref(ctx context.Context, serviceID, keyName, keyType string) (string, error)
+	// GetHeartbeatMonitor returns the href and id of the heartbeat monitor on the given service
+	// whose name matches monitorName, or ("","") if none exists.
+	GetHeartbeatMonitor(ctx context.Context, serviceID, monitorName string) (href string, id string, err error)
 }
 
 // Wrapper for HTTP client
@@ -123,6 +132,48 @@ type RespHeartbeatState struct {
 			LastState string `json:"lastState"`
 		} `json:"heartbeatMonitor"`
 	} `json:"data"`
+}
+
+// RespServiceSearch describes the services returned from a services search query.
+type RespServiceSearch struct {
+	Data struct {
+		Services struct {
+			Nodes []struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"nodes"`
+		} `json:"services"`
+	} `json:"data"`
+	Errors []GraphQLError `json:"errors,omitempty"`
+}
+
+// RespServiceIntKeys describes the integration keys returned from a service query.
+type RespServiceIntKeys struct {
+	Data struct {
+		Service struct {
+			IntegrationKeys []struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+				Type string `json:"type"`
+				Href string `json:"href"`
+			} `json:"integrationKeys"`
+		} `json:"service"`
+	} `json:"data"`
+	Errors []GraphQLError `json:"errors,omitempty"`
+}
+
+// RespServiceHeartbeats describes the heartbeat monitors returned from a service query.
+type RespServiceHeartbeats struct {
+	Data struct {
+		Service struct {
+			HeartbeatMonitors []struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+				Href string `json:"href"`
+			} `json:"heartbeatMonitors"`
+		} `json:"service"`
+	} `json:"data"`
+	Errors []GraphQLError `json:"errors,omitempty"`
 }
 
 // GraphQLError represents a single error in a GraphQL response.
@@ -319,4 +370,98 @@ func (c *GraphqlClient) IsHeartbeatMonitorInactive(ctx context.Context, data *Da
 		return false, nil
 	}
 	return true, nil
+}
+
+// GetServiceIDByName queries GoAlert for a service whose name exactly matches name and returns its ID, or "" if none exists.
+func (c *GraphqlClient) GetServiceIDByName(ctx context.Context, name string) (string, error) {
+	query := fmt.Sprintf(`query {services(input:{search:%s,first:100}){nodes{id name}}}`, strconv.Quote(name))
+
+	query = strings.ReplaceAll(query, "\t", "")
+	body := Q{Query: query}
+	respData, err := c.NewRequest(ctx, "POST", body)
+	if err != nil {
+		return "", err
+	}
+
+	var r RespServiceSearch
+	err = json.Unmarshal(respData, &r)
+	if err != nil {
+		return "", fmt.Errorf("unable to unmarshal response %s: %w", string(respData), err)
+	}
+
+	if len(r.Errors) > 0 {
+		return "", fmt.Errorf("GoAlert GraphQL error searching for service: %s", r.Errors[0].Message)
+	}
+
+	// GoAlert search is fuzzy/substring, so scan for the exact name match rather than
+	// returning the first node.
+	for _, node := range r.Data.Services.Nodes {
+		if node.Name == name {
+			return node.ID, nil
+		}
+	}
+
+	return "", nil
+}
+
+// GetIntegrationKeyHref queries GoAlert for an integration key on the given service whose name matches keyName and returns its href, or "" if none exists.
+func (c *GraphqlClient) GetIntegrationKeyHref(ctx context.Context, serviceID, keyName, keyType string) (string, error) {
+	query := fmt.Sprintf(`query {service(id:%s){integrationKeys{id name type href}}}`, strconv.Quote(serviceID))
+
+	query = strings.ReplaceAll(query, "\t", "")
+	body := Q{Query: query}
+	respData, err := c.NewRequest(ctx, "POST", body)
+	if err != nil {
+		return "", err
+	}
+
+	var r RespServiceIntKeys
+	err = json.Unmarshal(respData, &r)
+	if err != nil {
+		return "", fmt.Errorf("unable to unmarshal response %s: %w", string(respData), err)
+	}
+
+	if len(r.Errors) > 0 {
+		return "", fmt.Errorf("GoAlert GraphQL error querying integration keys: %s", r.Errors[0].Message)
+	}
+
+	// Match by name only. keyType is accepted for interface symmetry but is not used for
+	// matching because GoAlert returns the type as a JSON string while creates send it as an enum.
+	for _, key := range r.Data.Service.IntegrationKeys {
+		if key.Name == keyName {
+			return key.Href, nil
+		}
+	}
+
+	return "", nil
+}
+
+// GetHeartbeatMonitor queries GoAlert for a heartbeat monitor on the given service whose name matches monitorName and returns its href and id, or ("","") if none exists.
+func (c *GraphqlClient) GetHeartbeatMonitor(ctx context.Context, serviceID, monitorName string) (string, string, error) {
+	query := fmt.Sprintf(`query {service(id:%s){heartbeatMonitors{id name href}}}`, strconv.Quote(serviceID))
+
+	query = strings.ReplaceAll(query, "\t", "")
+	body := Q{Query: query}
+	respData, err := c.NewRequest(ctx, "POST", body)
+	if err != nil {
+		return "", "", err
+	}
+
+	var r RespServiceHeartbeats
+	err = json.Unmarshal(respData, &r)
+	if err != nil {
+		return "", "", fmt.Errorf("unable to unmarshal response %s: %w", string(respData), err)
+	}
+
+	if len(r.Errors) > 0 {
+		return "", "", fmt.Errorf("GoAlert GraphQL error querying heartbeat monitors: %s", r.Errors[0].Message)
+	}
+
+	for _, monitor := range r.Data.Service.HeartbeatMonitors {
+		if monitor.Name == monitorName {
+			return monitor.Href, monitor.ID, nil
+		}
+	}
+
+	return "", "", nil
 }

--- a/pkg/goalert/service_test.go
+++ b/pkg/goalert/service_test.go
@@ -414,3 +414,239 @@ func TestDeleteService(t *testing.T) {
 		})
 	}
 }
+
+func Test_GetServiceIDByName(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		searchName  string
+		expectedID  string
+		respData    []byte
+		expectedErr bool
+	}{
+		{
+			name:       "Exact name match among fuzzy results returns matching id not first node",
+			searchName: "fedramp-abc123 - High",
+			expectedID: "high-id",
+			// Low is listed first; the impl must scan for the exact-name match rather
+			// than returning nodes[0].
+			respData:    []byte(`{"data":{"services":{"nodes":[{"id":"low-id","name":"fedramp-abc123 - Low"},{"id":"high-id","name":"fedramp-abc123 - High"}]}}}`),
+			expectedErr: false,
+		},
+		{
+			name:        "No matching service returns empty and no error",
+			searchName:  "fedramp-abc123 - High",
+			expectedID:  "",
+			respData:    []byte(`{"data":{"services":{"nodes":[]}}}`),
+			expectedErr: false,
+		},
+		{
+			name:        "GraphQL errors array returns error",
+			searchName:  "fedramp-abc123 - High",
+			expectedID:  "",
+			respData:    []byte(`{"data":{"services":null},"errors":[{"message":"boom"}]}`),
+			expectedErr: true,
+		},
+		{
+			name:        "Failed unmarshalling response",
+			searchName:  "fedramp-abc123 - High",
+			expectedID:  "",
+			respData:    []byte(`garbagebody`),
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				resp := test.respData
+
+				w.WriteHeader(http.StatusOK)
+				if _, err := w.Write(resp); err != nil {
+					t.Fatalf("Unexpected error writing response from httptest server")
+				}
+			}))
+			defer mockServer.Close()
+
+			t.Setenv(config.GoalertApiEndpointEnvVar, mockServer.URL)
+			mockClient := &GraphqlClient{
+				sessionCookie: &http.Cookie{
+					Name: "test_cookie",
+				},
+				httpClient: mockServer.Client(),
+			}
+
+			actualID, err := mockClient.GetServiceIDByName(ctx, test.searchName)
+			if test.expectedErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Equal(t, test.expectedID, actualID)
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func Test_GetIntegrationKeyHref(t *testing.T) {
+
+	tests := []struct {
+		name         string
+		serviceID    string
+		keyName      string
+		keyType      string
+		expectedHref string
+		respData     []byte
+		expectedErr  bool
+	}{
+		{
+			name:         "Found integration key by name returns its href",
+			serviceID:    "svc-1",
+			keyName:      "High alerts",
+			keyType:      "prometheusAlertmanager",
+			expectedHref: "/api/v2/generic/incoming?token=high",
+			respData:     []byte(`{"data":{"service":{"integrationKeys":[{"id":"k1","name":"Low alerts","type":"prometheusAlertmanager","href":"/api/v2/generic/incoming?token=low"},{"id":"k2","name":"High alerts","type":"prometheusAlertmanager","href":"/api/v2/generic/incoming?token=high"}]}}}`),
+			expectedErr:  false,
+		},
+		{
+			name:         "No matching integration key returns empty and no error",
+			serviceID:    "svc-1",
+			keyName:      "High alerts",
+			keyType:      "prometheusAlertmanager",
+			expectedHref: "",
+			respData:     []byte(`{"data":{"service":{"integrationKeys":[]}}}`),
+			expectedErr:  false,
+		},
+		{
+			name:         "GraphQL errors array returns error",
+			serviceID:    "svc-1",
+			keyName:      "High alerts",
+			keyType:      "prometheusAlertmanager",
+			expectedHref: "",
+			respData:     []byte(`{"data":{"service":null},"errors":[{"message":"boom"}]}`),
+			expectedErr:  true,
+		},
+		{
+			name:         "Failed unmarshalling response",
+			serviceID:    "svc-1",
+			keyName:      "High alerts",
+			keyType:      "prometheusAlertmanager",
+			expectedHref: "",
+			respData:     []byte(`garbagebody`),
+			expectedErr:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				resp := test.respData
+
+				w.WriteHeader(http.StatusOK)
+				if _, err := w.Write(resp); err != nil {
+					t.Fatalf("Unexpected error writing response from httptest server")
+				}
+			}))
+			defer mockServer.Close()
+
+			t.Setenv(config.GoalertApiEndpointEnvVar, mockServer.URL)
+			mockClient := &GraphqlClient{
+				sessionCookie: &http.Cookie{
+					Name: "test_cookie",
+				},
+				httpClient: mockServer.Client(),
+			}
+
+			href, err := mockClient.GetIntegrationKeyHref(ctx, test.serviceID, test.keyName, test.keyType)
+			if test.expectedErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Equal(t, test.expectedHref, href)
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func Test_GetHeartbeatMonitor(t *testing.T) {
+
+	tests := []struct {
+		name         string
+		serviceID    string
+		monitorName  string
+		expectedHref string
+		expectedId   string
+		respData     []byte
+		expectedErr  bool
+	}{
+		{
+			name:         "Found heartbeat monitor by name returns href and id",
+			serviceID:    "svc-1",
+			monitorName:  "fedramp-abc123",
+			expectedHref: "/api/v2/heartbeat/abc",
+			expectedId:   "hb-1",
+			respData:     []byte(`{"data":{"service":{"heartbeatMonitors":[{"id":"hb-1","name":"fedramp-abc123","href":"/api/v2/heartbeat/abc"}]}}}`),
+			expectedErr:  false,
+		},
+		{
+			name:         "No matching heartbeat monitor returns empty and no error",
+			serviceID:    "svc-1",
+			monitorName:  "fedramp-abc123",
+			expectedHref: "",
+			expectedId:   "",
+			respData:     []byte(`{"data":{"service":{"heartbeatMonitors":[]}}}`),
+			expectedErr:  false,
+		},
+		{
+			name:         "GraphQL errors array returns error",
+			serviceID:    "svc-1",
+			monitorName:  "fedramp-abc123",
+			expectedHref: "",
+			expectedId:   "",
+			respData:     []byte(`{"data":{"service":null},"errors":[{"message":"boom"}]}`),
+			expectedErr:  true,
+		},
+		{
+			name:         "Failed unmarshalling response",
+			serviceID:    "svc-1",
+			monitorName:  "fedramp-abc123",
+			expectedHref: "",
+			expectedId:   "",
+			respData:     []byte(`garbagebody`),
+			expectedErr:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				resp := test.respData
+
+				w.WriteHeader(http.StatusOK)
+				if _, err := w.Write(resp); err != nil {
+					t.Fatalf("Unexpected error writing response from httptest server")
+				}
+			}))
+			defer mockServer.Close()
+
+			t.Setenv(config.GoalertApiEndpointEnvVar, mockServer.URL)
+			mockClient := &GraphqlClient{
+				sessionCookie: &http.Cookie{
+					Name: "test_cookie",
+				},
+				httpClient: mockServer.Client(),
+			}
+
+			href, id, err := mockClient.GetHeartbeatMonitor(ctx, test.serviceID, test.monitorName)
+			if test.expectedErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Equal(t, test.expectedHref, href)
+				assert.Equal(t, test.expectedId, id)
+				assert.Nil(t, err)
+			}
+		})
+	}
+}

--- a/pkg/goalert/service_test.go
+++ b/pkg/goalert/service_test.go
@@ -151,8 +151,8 @@ func Test_CreateService(t *testing.T) {
 				EscalationPolicyID: "123-bad",
 			},
 			expectedID:  "",
-			respData:    []byte(`{"data":{"createService":null}}`),
-			expectedErr: false,
+			respData:    []byte(`{"data":{"createService":null},"errors":[{"message":"escalation policy not found"}]}`),
+			expectedErr: true,
 		},
 		{
 			name: "Failed unmarshalling response",
@@ -229,8 +229,8 @@ func Test_CreateIntegrationKey(t *testing.T) {
 				Name: "Test Integration Key",
 			},
 			expectedKey: "",
-			respData:    []byte(`{"data":{"createIntegrationKey":null}}`),
-			expectedErr: false,
+			respData:    []byte(`{"data":{"createIntegrationKey":null},"errors":[{"message":"service not found"}]}`),
+			expectedErr: true,
 		},
 		{
 			name: "Failed unmarshalling response",
@@ -308,8 +308,8 @@ func Test_CreateHeartbeatMonitor(t *testing.T) {
 			},
 			expectedKey: "",
 			expectedId:  "",
-			respData:    []byte(`{"data":{"createHeartbeatMonitor":null}}`),
-			expectedErr: false,
+			respData:    []byte(`{"data":{"createHeartbeatMonitor":null},"errors":[{"message":"service not found"}]}`),
+			expectedErr: true,
 		},
 		{
 			name: "Failed unmarshalling response",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GoAlert resources can now be found and reused instead of duplicated.
  * Existing services, integration keys, and heartbeat monitors are handled safely during reconciliation.
* **Bug Fixes**
  * Prevented incomplete credentials from being saved.
  * Existing resources with missing credentials are automatically repaired on subsequent reconciliation.
  * ConfigMap updates now continue reconciliation correctly.
* **Documentation**
  * Updated API, integration, error-handling, testing, and provisioning guidance.
* **Tests**
  * Added coverage for resource adoption, error handling, credential validation, and self-healing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->